### PR TITLE
bump version in Cargo with release PR branch

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,6 +56,20 @@ jobs:
         with:
           base-ref: ${{ fromJSON(needs.release-pr.outputs.release_pr).current_tag }}
           head-ref: main
+      - name: Bump version in Cargo.{toml,lock}
+        if: fromJSON(needs.release-pr.outputs.release_pr).next_tag != ''
+        run: |
+          cargo install cargo-edit
+          cargo set-version ${{ fromJSON(needs.release-pr.outputs.release_pr).next_tag }}
+      - uses: chainguard-dev/actions/setup-gitsign@0cda751b114eb55c388e88f7479292668165602a # v1.0.2
+      - run: |
+          git add Cargo.{toml,lock}
+          if git diff --cached --exit-code; then
+            echo "No changes to commit"
+          else
+            git commit -m 'Bump version to ${{ fromJSON(needs.release-pr.outputs.release_pr).next_tag }}'
+            git push
+          fi
 
   verify-releaser:
     needs: [release-pr]


### PR DESCRIPTION
## Summary
- Replace TODO comment with actual git diff check in release workflow
- Prevent empty commits when no changes are made to Cargo files
- Only commit and push when there are actual staged changes

## Test plan
- [ ] Verify workflow runs successfully when Cargo files are modified
- [ ] Verify workflow skips commit/push when no changes are present

🤖 Generated with [Claude Code](https://claude.ai/code)