### PR TITLE
fix: strip 'v' prefix from version tag for cargo set-version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,13 +56,15 @@ jobs:
         with:
           base-ref: ${{ fromJSON(needs.release-pr.outputs.release_pr).current_tag }}
           head-ref: main
+      - uses: chainguard-dev/actions/setup-gitsign@0cda751b114eb55c388e88f7479292668165602a # v1.0.2
       - name: Bump version in Cargo.{toml,lock}
         if: fromJSON(needs.release-pr.outputs.release_pr).next_tag != ''
         run: |
           cargo install cargo-edit
-          cargo set-version ${{ fromJSON(needs.release-pr.outputs.release_pr).next_tag }}
-      - uses: chainguard-dev/actions/setup-gitsign@0cda751b114eb55c388e88f7479292668165602a # v1.0.2
-      - run: |
+          VERSION=${{ fromJSON(needs.release-pr.outputs.release_pr).next_tag }}
+          # Remove 'v' prefix if present for cargo set-version
+          VERSION=${VERSION#v}
+          cargo set-version "$VERSION"
           git add Cargo.{toml,lock}
           if git diff --cached --exit-code; then
             echo "No changes to commit"


### PR DESCRIPTION
## Summary
- Strip 'v' prefix from version tags before passing to cargo set-version
- cargo set-version expects semantic version format without 'v' prefix (e.g., "0.1.1" instead of "v0.1.1")

## Test plan
- [ ] Verify workflow correctly strips 'v' prefix from tags like "v0.1.1"
- [ ] Verify cargo set-version succeeds with the stripped version number

🤖 Generated with [Claude Code](https://claude.ai/code)