### PR TITLE
feat: Add version flag with git commit hash

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,64 @@
+use std::process::Command;
+
+fn main() {
+    // Get git commit hash
+    let output = Command::new("git")
+        .args(&["rev-parse", "--short", "HEAD"])
+        .output()
+        .ok();
+
+    let git_hash = match output {
+        Some(output) if output.status.success() => {
+            String::from_utf8(output.stdout)
+                .unwrap_or_else(|_| "unknown".to_string())
+                .trim()
+                .to_string()
+        }
+        _ => "unknown".to_string(),
+    };
+
+    // Check if working tree is dirty
+    let dirty_output = Command::new("git")
+        .args(&["diff-index", "--quiet", "HEAD"])
+        .status()
+        .ok();
+
+    let is_dirty = match dirty_output {
+        Some(status) => !status.success(),
+        None => false,
+    };
+
+    let git_suffix = if is_dirty {
+        format!("{}-dirty", git_hash)
+    } else {
+        git_hash
+    };
+
+    // Get the current tag if on a tag
+    let tag_output = Command::new("git")
+        .args(&["describe", "--exact-match", "--tags", "HEAD"])
+        .output()
+        .ok();
+
+    let on_tag = match tag_output {
+        Some(output) if output.status.success() => {
+            let tag = String::from_utf8(output.stdout)
+                .unwrap_or_else(|_| String::new())
+                .trim()
+                .to_string();
+            !tag.is_empty()
+        }
+        _ => false,
+    };
+
+    // Only set GIT_VERSION_SUFFIX if not on a tag
+    if on_tag {
+        println!("cargo:rustc-env=GIT_VERSION_SUFFIX=");
+    } else {
+        println!("cargo:rustc-env=GIT_VERSION_SUFFIX= ({})", git_suffix);
+    }
+
+    // Rebuild if git state changes
+    println!("cargo:rerun-if-changed=.git/HEAD");
+    println!("cargo:rerun-if-changed=.git/index");
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,9 +6,15 @@ use std::fs;
 mod io;
 use io::{read_file_or_stdin, write_output};
 
+const VERSION: &str = concat!(
+    env!("CARGO_PKG_VERSION"),
+    env!("GIT_VERSION_SUFFIX")
+);
+
 #[derive(Parser)]
 #[command(name = "kugiri")]
 #[command(about = "Marker-based block editing CLI", long_about = None)]
+#[command(version = VERSION)]
 struct Cli {
     #[command(subcommand)]
     command: Commands,


### PR DESCRIPTION
## Summary
- Add `--version`/`-V` flag to display version information
- Include git commit hash for non-tagged builds to help identify exact build version
- Add `-dirty` suffix when working tree has uncommitted changes

## Details
This PR enhances the version display functionality:
- **On git tags**: Shows clean version (e.g., `kugiri 0.1.4`)
- **On non-tag commits**: Shows version with commit hash (e.g., `kugiri 0.1.4 (039bc93)`)
- **With uncommitted changes**: Adds -dirty suffix (e.g., `kugiri 0.1.4 (039bc93-dirty)`)

This helps users and developers identify the exact version they're running, which is especially useful for development builds between releases.

## Test plan
- [x] Build on a tagged release and verify clean version display
- [x] Build on a non-tagged commit and verify git hash is shown
- [x] Make local changes and verify -dirty suffix appears
- [x] Test both `--version` and `-V` flags work

🤖 Generated with [Claude Code](https://claude.ai/code)