### PR TITLE
feat: Add stdin support for trim command

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -2,6 +2,7 @@ use anyhow::Result;
 use clap::{Parser, Subcommand};
 use kugiri::{extract, insert, remove, trim, update, upsert, wrap};
 use std::fs;
+use std::io::Read;
 
 mod io;
 use io::{read_file_or_stdin, write_output};
@@ -94,7 +95,8 @@ enum Commands {
     },
     /// Output the file with all marker lines removed
     Trim {
-        /// File to read
+        /// File to read (use '-' for stdin)
+        #[arg(default_value = "-")]
         file: String,
     },
     /// Wrap content with KUGIRI markers
@@ -160,7 +162,13 @@ fn main() -> Result<()> {
             println!("{result}");
         }
         Commands::Trim { file } => {
-            let text = fs::read_to_string(&file)?;
+            let text = if file == "-" {
+                let mut buffer = String::new();
+                std::io::stdin().read_to_string(&mut buffer)?;
+                buffer
+            } else {
+                fs::read_to_string(&file)?
+            };
             let result = trim(&text);
             println!("{result}");
         }


### PR DESCRIPTION
## Summary
- Added stdin support to the `kugiri trim` command
- The command now defaults to reading from stdin when no file is provided
- Users can explicitly use `-` to read from stdin or provide a file path

## Changes
- Modified the `Trim` command in `src/main.rs` to accept stdin input by default
- Added logic to read from stdin when the file argument is `-`
- Made the file argument default to `-` for consistency with other commands

## Test plan
- [x] Tested reading from stdin with pipe: `echo "content" | kugiri trim`
- [x] Tested explicit stdin flag: `kugiri trim -`
- [x] Tested file input: `kugiri trim file.txt`
- [x] All existing tests pass: `cargo test`
- [x] Linting passes: `cargo clippy`
- [x] Code is formatted: `cargo fmt`

🤖 Generated with [Claude Code](https://claude.ai/code)