### PR TITLE
feat: Add smart-commit action with git trailer detection

### DIFF
--- a/.github/actions/smart-commit/action.yml
+++ b/.github/actions/smart-commit/action.yml
@@ -1,0 +1,96 @@
+name: 'Smart Commit with Trailer Detection'
+description: 'Creates or replaces commits based on git trailer detection'
+inputs:
+  commit_message:
+    description: 'Commit message (can be multiline)'
+    required: true
+  trailer_id:
+    description: 'Unique identifier for the trailer (e.g., changelog-update)'
+    required: true
+  branch:
+    description: 'Target branch'
+    required: true
+  files:
+    description: 'Files to commit (newline-separated)'
+    required: true
+  github_token:
+    description: 'GitHub token for API operations'
+    required: false
+    default: ${{ github.token }}
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Check for changes
+      id: check-changes
+      shell: bash
+      env:
+        FILES: ${{ inputs.files }}
+      run: |
+        # Convert newline-separated files to space-separated for git diff
+        FILES_LIST=$(echo "$FILES" | tr '\n' ' ')
+
+        # Check if there are any changes in the specified files
+        if git diff --quiet HEAD -- $FILES_LIST && git diff --cached --quiet HEAD -- $FILES_LIST; then
+          echo "No changes detected in specified files"
+          echo "has_changes=false" >> $GITHUB_OUTPUT
+        else
+          echo "Changes detected in specified files"
+          echo "has_changes=true" >> $GITHUB_OUTPUT
+        fi
+
+    - name: Check if HEAD has matching trailer
+      if: steps.check-changes.outputs.has_changes == 'true'
+      id: check-trailer
+      shell: bash
+      env:
+        TRAILER_ID: ${{ inputs.trailer_id }}
+      run: |
+        # Check if HEAD commit has our trailer using git interpret-trailers
+        COMMIT_MSG=$(git log -1 --format=%B)
+        TRAILER_VALUE=$(echo "$COMMIT_MSG" | git interpret-trailers --parse | grep "^X-Smart-Commit-ID:" | cut -d' ' -f2- || true)
+
+        if [ "$TRAILER_VALUE" = "$TRAILER_ID" ]; then
+          echo "HEAD has matching trailer (X-Smart-Commit-ID: $TRAILER_ID)"
+          echo "should_reset=true" >> $GITHUB_OUTPUT
+          # Store parent SHA for later use
+          PARENT_SHA=$(git rev-parse HEAD~1)
+          echo "parent_sha=$PARENT_SHA" >> $GITHUB_OUTPUT
+        else
+          echo "HEAD does not have matching trailer"
+          echo "should_reset=false" >> $GITHUB_OUTPUT
+        fi
+
+    - name: Reset to parent if needed
+      if: steps.check-changes.outputs.has_changes == 'true' && steps.check-trailer.outputs.should_reset == 'true'
+      shell: bash
+      env:
+        GITHUB_TOKEN: ${{ inputs.github_token }}
+        BRANCH: ${{ inputs.branch }}
+        PARENT_SHA: ${{ steps.check-trailer.outputs.parent_sha }}
+      run: |
+        echo "Resetting branch to parent commit: $PARENT_SHA"
+
+        # Use GitHub API to update the branch reference to parent
+        curl -X PATCH \
+          -H "Authorization: token $GITHUB_TOKEN" \
+          -H "Accept: application/vnd.github.v3+json" \
+          "https://api.github.com/repos/${{ github.repository }}/git/refs/heads/$BRANCH" \
+          -d "{\"sha\":\"$PARENT_SHA\",\"force\":true}"
+
+    - name: Create commit with trailer
+      if: steps.check-changes.outputs.has_changes == 'true'
+      uses: suzuki-shunsuke/commit-action@ca8e761ccb3533295065c3e90a8555fcdde8b467 # v0.0.10
+      with:
+        commit_message: |
+          ${{ inputs.commit_message }}
+
+          X-Smart-Commit-ID: ${{ inputs.trailer_id }}
+        branch: ${{ inputs.branch }}
+        files: ${{ inputs.files }}
+
+    - name: Sync local git state with remote
+      if: steps.check-changes.outputs.has_changes == 'true'
+      uses: actions/checkout@v5
+      with:
+        ref: ${{ inputs.branch }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,11 +49,13 @@ jobs:
       - uses: actions/checkout@v5
         with:
           ref: ${{ fromJSON(needs.release-pr.outputs.release_pr).pr_branch }}
+          fetch-depth: 2  # Need at least 2 commits to check and potentially reset
       - uses: actions/dependency-review-action@v4
         id: dependency-review
         with:
           base-ref: ${{ fromJSON(needs.release-pr.outputs.release_pr).current_tag }}
           head-ref: main
+
       - name: Update README installation section
         if: fromJSON(needs.release-pr.outputs.release_pr).next_tag != ''
         env:
@@ -64,13 +66,79 @@ jobs:
           # Update README with new version
           ./scripts/update-installation.sh "$VERSION"
 
-      - uses: suzuki-shunsuke/commit-action@ca8e761ccb3533295065c3e90a8555fcdde8b467 # v0.0.10
+      - uses: ./.github/actions/smart-commit
         with:
           commit_message: "docs: Update README installation section to ${{ fromJSON(needs.release-pr.outputs.release_pr).next_tag }}"
+          trailer_id: readme-update
           branch: ${{ fromJSON(needs.release-pr.outputs.release_pr).pr_branch }}
           files: |
             README.md
 
+
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache cargo dependencies
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-
+
+      - name: Install cargo-edit
+        if: fromJSON(needs.release-pr.outputs.release_pr).next_tag != ''
+        uses: taiki-e/cache-cargo-install-action@b33c63d3b3c85540f4eba8a4f71a5cc0ce030855 # v2.3.0
+        with:
+          tool: cargo-edit
+      - name: Bump version in Cargo.{toml,lock}
+        if: fromJSON(needs.release-pr.outputs.release_pr).next_tag != ''
+        env:
+          VERSION: ${{ fromJSON(needs.release-pr.outputs.release_pr).next_tag }}
+        run: |
+          # Remove 'v' prefix if present for cargo set-version
+          VERSION=${VERSION#v}
+          cargo set-version "$VERSION"
+
+      - uses: ./.github/actions/smart-commit
+        if: fromJSON(needs.release-pr.outputs.release_pr).next_tag != ''
+        with:
+          commit_message: "chore: Bump version to ${{ fromJSON(needs.release-pr.outputs.release_pr).next_tag }}"
+          trailer_id: cargo-version-bump
+          branch: ${{ fromJSON(needs.release-pr.outputs.release_pr).pr_branch }}
+          files: |
+            Cargo.toml
+            Cargo.lock
+
+      - uses: mlugg/setup-zig@8d6198c65fb0feaa111df26e6b467fea8345e46f # v2.0.5
+      - uses: sigstore/cosign-installer@v3.9.2 # installs cosign
+      - uses: anchore/sbom-action/download-syft@v0.20.5 # installs syft
+      # Pre-install cargo-zigbuild before exposing MinGW to avoid Linux linker hijack
+      - name: Preinstall cargo-zigbuild
+        uses: taiki-e/cache-cargo-install-action@b33c63d3b3c85540f4eba8a4f71a5cc0ce030855 # v2.3.0
+        with:
+          tool: cargo-zigbuild
+          locked: true
+      # Provide dlltool for windows-gnu without hijacking cc/c++
+      - name: Install mingw binutils (dlltool)
+        uses: awalsh128/cache-apt-pkgs-action@2c09a5e66da6c8016428a2172bd76e5e4f14bb17 # v1.5.3
+        with:
+          packages: binutils-mingw-w64
+          version: 1.0
+      - uses: goreleaser/goreleaser-action@v6
+        id: goreleaser
+        with:
+          version: '~> v2'
+          args: release --clean --draft --snapshot --skip publish
+      - uses: actions/upload-artifact@v4
+        with:
+          name: snapshot
+          path: ./dist
+
+      # Update CHANGELOG last as it's most likely to change
       - name: Update CHANGELOG with release notes
         if: fromJSON(needs.release-pr.outputs.release_pr).next_tag != ''
         env:
@@ -111,72 +179,13 @@ jobs:
               --write
           fi
 
-      - uses: suzuki-shunsuke/commit-action@ca8e761ccb3533295065c3e90a8555fcdde8b467 # v0.0.10
+      - uses: ./.github/actions/smart-commit
         with:
           commit_message: "docs: Update CHANGELOG for ${{ fromJSON(needs.release-pr.outputs.release_pr).next_tag }}"
+          trailer_id: changelog-update
           branch: ${{ fromJSON(needs.release-pr.outputs.release_pr).pr_branch }}
           files: |
             CHANGELOG.md
-
-      - name: Setup Rust
-        uses: dtolnay/rust-toolchain@stable
-
-      - name: Cache cargo dependencies
-        uses: actions/cache@v4
-        with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            target
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-cargo-
-
-      - name: Install cargo-edit
-        if: fromJSON(needs.release-pr.outputs.release_pr).next_tag != ''
-        uses: taiki-e/cache-cargo-install-action@b33c63d3b3c85540f4eba8a4f71a5cc0ce030855 # v2.3.0
-        with:
-          tool: cargo-edit
-      - name: Bump version in Cargo.{toml,lock}
-        if: fromJSON(needs.release-pr.outputs.release_pr).next_tag != ''
-        env:
-          VERSION: ${{ fromJSON(needs.release-pr.outputs.release_pr).next_tag }}
-        run: |
-          # Remove 'v' prefix if present for cargo set-version
-          VERSION=${VERSION#v}
-          cargo set-version "$VERSION"
-          git add Cargo.{toml,lock}
-          if git diff --cached --exit-code; then
-            echo "No changes to commit"
-          else
-            git commit -m "Bump version to $VERSION"
-            git push
-          fi
-
-      - uses: mlugg/setup-zig@8d6198c65fb0feaa111df26e6b467fea8345e46f # v2.0.5
-      - uses: sigstore/cosign-installer@v3.9.2 # installs cosign
-      - uses: anchore/sbom-action/download-syft@v0.20.5 # installs syft
-      # Pre-install cargo-zigbuild before exposing MinGW to avoid Linux linker hijack
-      - name: Preinstall cargo-zigbuild
-        uses: taiki-e/cache-cargo-install-action@b33c63d3b3c85540f4eba8a4f71a5cc0ce030855 # v2.3.0
-        with:
-          tool: cargo-zigbuild
-          locked: true
-      # Provide dlltool for windows-gnu without hijacking cc/c++
-      - name: Install mingw binutils (dlltool)
-        uses: awalsh128/cache-apt-pkgs-action@2c09a5e66da6c8016428a2172bd76e5e4f14bb17 # v1.5.3
-        with:
-          packages: binutils-mingw-w64
-          version: 1.0
-      - uses: goreleaser/goreleaser-action@v6
-        id: goreleaser
-        with:
-          version: '~> v2'
-          args: release --clean --draft --snapshot --skip publish
-      - uses: actions/upload-artifact@v4
-        with:
-          name: snapshot
-          path: ./dist
 
   verify-releaser:
     needs: [release-pr]


### PR DESCRIPTION
## Summary
- Implements a composite action that intelligently manages commits based on git trailers
- Prevents accumulation of auto-generated commits in release PRs
- All release workflow commits now use smart-commit with unique trailer IDs

## Problem
The release workflow was creating new commits on every run, leading to:
- Multiple CHANGELOG update commits accumulating
- Multiple README update commits accumulating  
- Cluttered git history in release PRs

## Solution
Created a `smart-commit` composite action that:
1. Checks if files have actual changes (prevents empty commits)
2. Uses `git interpret-trailers --parse` to detect previous commits with the same trailer ID
3. If found, uses GitHub API to reset the branch ref to the parent commit
4. Creates a new commit with the trailer ID
5. Syncs local git state with remote using `actions/checkout`

## Changes
### New composite action (`.github/actions/smart-commit/`)
- Detects and replaces previous auto-generated commits
- Each commit type gets a unique trailer ID
- Maintains verified commit status through `commit-action`

### Updated release workflow
- All commits now use `smart-commit` action
- Trailer IDs: `changelog-update`, `readme-update`, `cargo-version-bump`
- CHANGELOG update moved to the end (most likely to change)

## Test plan
- [ ] Release PR creation works as before
- [ ] On second run, previous auto-generated commits are replaced, not stacked
- [ ] No empty commits are created when files haven't changed
- [ ] Verified commits are maintained

🤖 Generated with [Claude Code](https://claude.ai/code)